### PR TITLE
Don't run Present hook if test flag is set

### DIFF
--- a/OpenVHook/DirectXHook/DirectXHook.cpp
+++ b/OpenVHook/DirectXHook/DirectXHook.cpp
@@ -33,6 +33,11 @@ static Vector2 windowSize = Vector2();
 Fn_IDXGISwapChain_Present g_orig_IDXGISwapChain_Present = nullptr;
 HRESULT WINAPI New_IDXGISwapChain_Present(IDXGISwapChain* chain, UINT syncInterval, UINT flags)
 {
+	if (flags & DXGI_PRESENT_TEST)
+	{
+		return g_orig_IDXGISwapChain_Present(chain, syncInterval, flags);
+	}
+
 	if (!g_D3DHook.m_IsResizing)
 	{
 		if (g_D3DHook.m_pSwapchain == nullptr)


### PR DESCRIPTION
Scripthook checks if `flags` has bit 1 set, which in this case is `DXGI_PRESENT_TEST`. If so, it just calls the original Present.
![shv_presence](https://user-images.githubusercontent.com/4201956/169907726-866eb208-9876-4e3d-9bbd-193762d96c9f.png)
The lack of this check caused issues in our own Present hook (as it is being called at a different point than normal with that flag set). This properly mimics Scripthook's behavior.